### PR TITLE
[PHP 7.4 Compat] Remove overloaded offsetExists()

### DIFF
--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -194,16 +194,4 @@ class Zend_Registry extends ArrayObject
     {
         parent::__construct($array, $flags);
     }
-
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
-
 }


### PR DESCRIPTION
This blows up on PHP 7.4 because of the change to `array_key_exists()` which now strictly expects an `array`.
https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-key-exists-objects

This method looks like it was only added because of this bug https://bugs.php.net/bug.php?id=40442 which is exclusive to PHP 5.2.1 and was fixed in 5.2.2 - https://www.php.net/ChangeLog-5.php#5.2.2